### PR TITLE
[UPSTREAM] Fix a few bugs in ma/containers_groups

### DIFF
--- a/src/moser.app.src
+++ b/src/moser.app.src
@@ -8,8 +8,7 @@
                   stdlib,
 		  jiffy,
 		  sqerl,
-		  lager,
-                  oc_chef_authz
+		  lager
                  ]},
   {included_applications, []},
   {mod, { moser_app, []}},


### PR DESCRIPTION
Upstreamof ma/containers_groups. Fixes a few bugs in that branch. Related to https://github.com/opscode/chef-mover/pull/41 and https://github.com/opscode/opscode-platform-cookbooks/pull/433.

Attn @sdelano @manderson26 @oferrigni @marcparadise 
