### PR TITLE
Fixed issue where loading dets would break due to permissions.

### DIFF
--- a/src/moser_acct_processor.erl
+++ b/src/moser_acct_processor.erl
@@ -50,7 +50,7 @@
 %%%===================================================================
 
 open_account() ->
-    open_account([{access, read}]).
+    open_account([{access, read_write}]).
 
 open_account(Args) ->
     {ok, U2A} = moser_utils:dets_open_file(user_to_authz, Args),


### PR DESCRIPTION
If you called create_account_dets multiple times in a single mover session, it would crash after the first time, because it would attempt to open the dets tables with different permissions (read vs read_write). Always open with perms read_write fixes this issue.
