### PR TITLE
Remove mochiweb requirement so erchef can pick the version it wants

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,8 +9,6 @@
 
 {deps,
  [
-  {mochiweb, "1.5.1*",
-   {git, "git://github.com/basho/mochiweb.git", {tag, "1.5.1p6"}}},
   {lager, ".*",
    {git, "git://github.com/basho/lager.git", {branch, "master"}}},
   {decouch, ".*",


### PR DESCRIPTION
There's no tests so I have no idea if this will break anything, but it's totally blocking me from upgrading erchef in mover.